### PR TITLE
Troubleshoot connector deployment failure

### DIFF
--- a/connector.json
+++ b/connector.json
@@ -1,1 +1,1 @@
-{"name":"convex-aspire-crm","version":"1.2","title":"Aspire","description":"","service":{"name":"xy93Pi3w0gJbXz_convex-aspire","version":"1.0"},"tags":["service"],"isTrigger":false,"rawHttp":{"enabled":true}}
+{"name":"convex-aspire-crm","version":"1.3","title":"Aspire","description":"","service":{"name":"xy93Pi3w0gJbXz_convex-aspire","version":"1.0"},"tags":["service"],"isTrigger":false,"rawHttp":{"enabled":true}}

--- a/connector.json
+++ b/connector.json
@@ -1,1 +1,1 @@
-{"name":"convex-aspire-crm","version":"1.3","title":"Aspire","description":"","service":{"name":"xy93Pi3w0gJbXz_convex-aspire","version":"1.0"},"tags":["service"],"isTrigger":false,"rawHttp":{"enabled":true}}
+{"name":"convex-aspire-crm","version":"1.4","title":"Aspire","description":"","service":{"name":"xy93Pi3w0gJbXz_convex-aspire","version":"1.0"},"tags":["service"],"isTrigger":false,"rawHttp":{"enabled":true}}


### PR DESCRIPTION
Bump connector version to 1.3 to resolve "Connector already has a version" deployment error.

---
<a href="https://cursor.com/background-agent?bcId=bc-33dba295-6216-443e-bd60-a06efa233fc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33dba295-6216-443e-bd60-a06efa233fc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

